### PR TITLE
Use identical to compare box min max coords

### DIFF
--- a/R/geom_fit_text.R
+++ b/R/geom_fit_text.R
@@ -315,8 +315,8 @@ makeContent.fittexttree <- function(x) {
 
   # If xmin/xmax are not provided, or all xmin == xmax, generate boundary box
   # from width
-  if (!("xmin" %in% names(data)) | 
-      (all(data$xmin == data$xmax) & "x" %in% names(data))) {
+  if (!("xmin" %in% names(data)) |
+      (identical(data$xmin, data$xmax) & "x" %in% names(data))) {
     data$xmin <- data$x - (
       grid::convertWidth(
         grid::unit(x$width, "mm"),
@@ -335,8 +335,8 @@ makeContent.fittexttree <- function(x) {
 
   # If ymin/ymax are not provided, or all ymin == ymax, generate boundary box
   # from height
-  if (!("ymin" %in% names(data)) | 
-      (all(data$ymin == data$ymax) & 
+  if (!("ymin" %in% names(data)) |
+      (identical(data$ymin, data$ymax) &
        "y" %in% names(data))) {
     data$ymin <- data$y - (
       grid::convertHeight(


### PR DESCRIPTION
I'm using another package that uses ggfittext -- [alastairrushworth/inspectdf](https://github.com/alastairrushworth/inspectdf) -- and have stumbled upon an issue in `makeContent.fittexttree()` caused by this line:

https://github.com/wilkox/ggfittext/blob/155e1843ba6777c990bf06c9d66eb6d2d773c59e/R/geom_fit_text.R#L339

which results in this error when `data$ymax` is `NA`

```
Error in if (!("ymin" %in% names(data)) | (all(data$ymin == data$ymax) &  : 
  missing value where TRUE/FALSE needed
```

When I get to that line, `data` contains the following

```r
Browse[6]> data
          y         x label group PANEL       xmin      xmax      ymin ymax alpha angle colour family fontface lineheight size
1 0.9342934 0.1153846  1300     1     1 0.02884615 0.2019231 0.2010393   NA     1    90  white               1        0.9   12
```

I'm not sure if the missing value is expected or indicative of an upstream error. Regardless, I think that replacing

```r
all(data$ymin == data$ymax)
```

with 

```r
identical(data$ymin, data$ymax)
```

would resolve this problem. 

Submitting this suggestion as a PR because it's easy enough. All tests passed, although I don't know enough about ggfittext's internals to know if this case is well-tested.

Anyway, hope this helps!

cc @alastairrushworth