### PR TITLE
Avoid using ggplot2 internal functions

### DIFF
--- a/R/geom_fit_text.R
+++ b/R/geom_fit_text.R
@@ -305,16 +305,16 @@ GeomFitText <- ggplot2::ggproto(
     # set the width and height of the bounding box in polar space
     if (inherits(coord, "CoordPolar")) {
       if (! is.null(data$xmin)) {
-        data$xmin <- ggplot2:::theta_rescale(coord, data$xmin, panel_scales)
+        data$xmin <- theta_rescale(coord, data$xmin, panel_scales)
       }
       if (! is.null(data$xmax)) {
-        data$xmax <- ggplot2:::theta_rescale(coord, data$xmax, panel_scales)
+        data$xmax <- theta_rescale(coord, data$xmax, panel_scales)
       }
       if (! is.null(data$ymin)) {
-        data$ymin <- ggplot2:::r_rescale(coord, data$ymin, panel_scales$r.range)
+        data$ymin <- r_rescale(coord, data$ymin, panel_scales$r.range)
       }
       if (! is.null(data$ymax)) {
-        data$ymax <- ggplot2:::r_rescale(coord, data$ymax, panel_scales$r.range)
+        data$ymax <- r_rescale(coord, data$ymax, panel_scales$r.range)
       }
     }
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -377,3 +377,17 @@ wrap_rich <- function(string, w) {
   wrapped_string <- paste(chars, collapse = "")
   return(wrapped_string)
 }
+
+theta_rescale <- function(coord, x, panel_params) {
+  range <- panel_params$theta.range
+  x <- pmin(pmax(x, range[1]), range[2])
+  rotate <- function(x) (x + coord$start) %% (2 * pi) * coord$direction
+  rotate(
+    (x - range[1]) / diff(range) * (2 * pi)
+  )
+}
+
+r_rescale <- function(coord, x, range) {
+  x <- pmin(pmax(x, range[1]), range[2])
+  (x - range[1]) / diff(range) * 0.4
+}


### PR DESCRIPTION
Hello there,

We have been preparing a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospective ggplot2 3.5.0 would break ggfittext.

The culprit of this breakage is the use of the internal `theta_rescale()` and `r_rescale()` functions. While ggplot2 attempt to maintain a reasonably stable interface for it exported functions, it makes no such promises for internal functions. This PR copies (an approximation of) the old functions, which makes ggfittext independent of the changes in the new internal functions.

To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled for the 12th of February. The progress of the release can be tracked in https://github.com/tidyverse/ggplot2/issues/5588. We hope that this PR might help ggfittext get out a fix if necessary.